### PR TITLE
全員にメッセージを配信する処理を実装

### DIFF
--- a/app/Http/Controllers/Api/V1/LineController.php
+++ b/app/Http/Controllers/Api/V1/LineController.php
@@ -4,15 +4,20 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use LINE\LINEBot;
+use LINE\LINEBot\HTTPClient\CurlHTTPClient;
+use LINE\LINEBot\MessageBuilder\TextMessageBuilder;
 
 class LineController extends Controller
 {
     // メッセージ送信
     public function delivery()
     {
-        // TODO: ここに具体的に実装
-
         // 1. 登録されている友だちにメッセージを送信
+        $httpClient = new CurlHTTPClient(env('LINE_CHANNEL_ACCESS_TOKEN'));
+        $bot = new LINEBot($httpClient, ['channelSecret' => env('CHANNEL_SECRET')]);
+        $textBuilder = new TextMessageBuilder('Hello LINE!');
+        $bot->broadcast($textBuilder);
 
         return response()->json(['message' => 'sent']);
     }


### PR DESCRIPTION
## 概要
全員にメッセージを配信する
※ボットを友だち登録している人が対象です

### 参考
[ブロードキャストメッセージを送る](https://developers.line.biz/ja/reference/messaging-api/#send-broadcast-message)
↑
※ 注意！:  動画撮影時からAPIのドキュメントに更新が入っています。 
リクエストに失敗する場合は `X-Line-Retry-Key` をはずして実行してみてください。
（あるいはドキュメントに習って独自のUUIDを指定するなど）
[Q&A 178.LINEbotでメッセージを送信できません。](https://www.udemy.com/course/web-app-development/learn/#questions/16161388/)

## 動作方法

### 1.  `.env`ファイルに、環境変数を追加
`.env` の以下の環境変数に設定
```
LINE_CHANNEL_ACCESS_TOKEN=ここにアクセストークンを指定
LINE_CHANNEL_SECRET=ここにチャネルシークレットを指定
```
※ `.env` はコミットしないように気をつけてください！（対象から外れるように`.gitignore`に書いていますが、念の為・・・）

- チャネルアクセストークン
    - 「Messaging API」 の一番下に「Channel access token」があります。
        (Issueボタンを押して発行してください)
- チャネルシークレット
    - 「Basic settings」の中に「Channel secret」という項目があります。

### 2. ボットを友だち登録する
「Messaging API」の中にQRコードがあるのでLINEで読み取って友だち登録しておいてください

### 3. リクエストしてみる
以下を実行する
```
curl --header 'Accept: application/json' http://localhost/api/v1/delivery
```

結果
![image](https://user-images.githubusercontent.com/1150769/107850431-bdbcd500-6e45-11eb-9a4a-22bf2a858cdf.png)


## 補足
https://packagist.org/packages/revolution/laravel-line-sdk を使うともっとシンプルに記述することは可能。（Laravelの使い方に慣れてきたらオススメ）