### PR TITLE
Webhook実装1: 署名を検証する処理を実装

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -62,5 +62,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'signedbyline' => \App\Http\Middleware\LineSignatureIsValid::class,
     ];
 }

--- a/app/Http/Middleware/LineSignatureIsValid.php
+++ b/app/Http/Middleware/LineSignatureIsValid.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class LineSignatureIsValid
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $channelSecret = env('LINE_CHANNEL_SECRET');
+        $httpRequestBody = $request->getContent();
+
+        // LINE公式サイトに書いている通りに署名検証用の文字列を用意する
+        // @see https://developers.line.biz/ja/reference/messaging-api/#signature-validation
+        $hash = hash_hmac('sha256', $httpRequestBody, $channelSecret, true);
+        $signature = base64_encode($hash);
+
+        // リクエストヘッダのx-line-signatureの文字列と、署名検証用の文字が一致するか確認
+        if ($request->header('x-line-signature') !== $signature) {
+            // 一致しない場合は403 Forbidden(認証拒否)
+            return response()->json([
+                'message' => 'invalid request',
+            ], 403);
+        }
+
+        // 次の処理(Controller等の処理)へ
+        return $next($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,4 +19,6 @@ use App\Http\Controllers\Api\V1\LineController;
 Route::get('/v1/delivery', [LineController::class, 'delivery']);
 
 // Webhookでメッセージを受け取る受け口
-Route::post('/v1/callback', [LineController::class, 'callback']);
+Route::post('/v1/callback', [LineController::class, 'callback'])
+    ->middleware('signedbyline');
+


### PR DESCRIPTION
## 概要
Webhook実装のために、署名を検証する処理を実装

### 参考
- [Messaging APIリファレンス（署名を検証する）](https://developers.line.biz/ja/reference/messaging-api/#signature-validation)
- [Middleware - Laravel - The PHP Framework For Web Artisans](https://laravel.com/docs/8.x/middleware)

## 実装方法
### 1. Middlewareクラスを新規に作成
以下で、作成できる
```
sail artisan make:middleware LineSignatureIsValid
```
中身の実装はコメント参考に。

### 2. routes で利用できるように設定
`app/Http/Kernel.php` の `$routeMiddleware` に `LineSignatureIsValid` を追加する。

### 3. routes にMiddlewareを設定
`routes/api.php` のMiddlewareを設定したいところに、 middlewareメソッドをつける。

## 動作確認
### 失敗することを確認
```
curl -i -XPOST --header 'Accept: application/json' http://localhost/api/v1/callback
```
実行すると、失敗するので403になる。（出力はinvalid request というメッセージになる）
※ curlの-i オプションは、includeの略で、headerも含めて出力するという意味です。

### 成功することを確認（ローカルで確認）

#### 1. phpでx-line-signatureヘッダの値を作成
```
php -a
```

```
$channelSecret = 'チャネルシークレットをここに指定';
$httpRequestBody = '';
$hash = hash_hmac('sha256', $httpRequestBody, $channelSecret, true);
echo base64_encode($hash);
```

<kbd>Ctrl</kbd> + <kbd>C</kbd> で終了

#### 2. x-line-signatureヘッダを付けてリクエストする
```
curl -i -XPOST \
    --header 'Accept: application/json' \
    --header 'x-line-signature: ここにPHPで出力した値を指定' \
    http://localhost/api/v1/callback
```

### 成功することを確認（LINE Developerコンソールで確認）
#### ngrokの起動
```
ngrok http -region=jp 80
```
起動できたらhttpsの方のURLをコピーする。

※ 上記で `ERROR:  unknown shorthand flag: 'r' in -region=jp` というエラーが出た場合は、以下を実行してください。
```
ngrok http --region=jp 80
```
(ngrok のバージョンがv3になったときにオプションの指定方法が変わりました）

#### LINE DevelopersのコンソールでWebhookの設定
チャネルにWebhookのURLを設定する。

ngrokで発行されたhttpsの方のURLをLINEの以下の部分に設定する。
![image](https://user-images.githubusercontent.com/1150769/107851068-6a00ba80-6e4a-11eb-82a5-544c1595a7f4.png)

上記設定後に「Verify」ボタンを押したら、以下の様になる。

ngrok の画面（コマンドラインの画面）
```
HTTP Requests
-------------

POST /api/v1/callback          200 OK
```

LINEの管理画面
![image](https://user-images.githubusercontent.com/1150769/107851113-cc59bb00-6e4a-11eb-9bca-7248e73c6e0f.png)
