### PR TITLE
PHP Intelephenseの警告が出ないようにコメントを追記

### DIFF
--- a/tests/Unit/Services/ReplyMessageGeneratorTest.php
+++ b/tests/Unit/Services/ReplyMessageGeneratorTest.php
@@ -62,9 +62,11 @@ class ReplyMessageGeneratorTest extends TestCase
     public function testGeneratorWithWeatherForecaster($expected, $apiResult)
     {
         // WeatherForecaster#forecast の挙動を変更するモックを作成
+        /** @var MockInterface */
         $weatherForecasterMock = Mockery::mock(WeatherForecaster::class);
         $weatherForecasterMock->shouldReceive('forecast')->andReturn($apiResult);
 
+        /** @var WeatherForecaster $weatherForecasterMock */
         $replyMessageGenerator = new ReplyMessageGenerator($weatherForecasterMock);
 
         $this->assertSame($replyMessageGenerator->generate('今日の天気は？'), $expected);


### PR DESCRIPTION
## 概要
コメントがない場合モックオブジェクトとReplyMessageGeneratorのコンストラクタの型が違うのでPHP Intelephenseで警告が出てしまう。
以下のように出る。
<img width="1235" alt="image" src="https://user-images.githubusercontent.com/1150769/166204619-6271abeb-66b5-4ce6-8048-97594c32aab7.png">

 コメントで型を指定することで警告が出ないようにする。

## 確認
- [x] 警告が出なくなっていること
- [x] テスト自体は正常に動くこと

### 警告が出なくなっていること
<img width="809" alt="image" src="https://user-images.githubusercontent.com/1150769/166204854-01e24935-cf85-43b4-a4c4-9815ef1cec28.png">


### テスト自体は正常に動くこと
```
❯ sail test

   PASS  Tests\Unit\ExternalApis\WeatherForecastApi\OpenWeatherMapTest
  ✓ parse with data set "正常なJSONの場合、今日(daily[0].weather[0].description)が取れる"
  ✓ parse with data set "フォーマットが異なるJSONの場合(dailyが空の場合)"
  ✓ parse with data set "フォーマットが異なるJSONの場合(dailyがない場合)"
  ✓ parse with data set "フォーマットが異なるJSONの場合(weatherがない場合)"
  ✓ parse with data set "フォーマットが異なるJSONの場合(weatherが空の場合)"
  ✓ parse with data set "フォーマットが異なるJSONの場合(descriptionがない場合)"

   PASS  Tests\Unit\Services\ReplyMessageGeneratorTest
  ✓ generator with data set "今日の天気は？"
  ✓ generator with data set "元気？"
  ✓ generator with data set "後ウマイヤ朝の最盛期王は？"
  ✓ generator with data set "文章の最後に「？」があるとき"
  ✓ generator with data set "文章の途中に「？」があるとき"
  ✓ generator with data set "どのパターンにも一致しないとき"
  ✓ generator with weather forecaster with data set "天気予報を取得できたとき"
  ✓ generator with weather forecaster with data set "天気予報を取得できなかったとき"

   PASS  Tests\Unit\Services\RequestParserTest
  ✓ get recieved messages with data set "何も受信できなかった場合"
  ✓ get recieved messages with data set "メッセージ情報がある場合"
  ✓ get recieved messages with data set "メッセージ情報がない場合"

   PASS  Tests\Feature\Api\V1\CallbackTest
  ✓ valid signature

  Tests:  18 passed
  Time:   0.70s
```

