### PR TITLE
docker-compose.yamlにversionが不要になったので削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # For more information: https://laravel.com/docs/sail
-version: '3'
 services:
     laravel.test:
         build:


### PR DESCRIPTION
## 概要
version の指定が不要になったので削除する

compose-spec/04-version-and-name.md at a8751e853209baf5f57ae191a3ebd0cf491b45b3 · compose-spec/compose-spec
https://github.com/compose-spec/compose-spec/blob/a8751e853209baf5f57ae191a3ebd0cf491b45b3/04-version-and-name.md?plain=1#L3-L11


## 確認
### 変更前
```
❯ sail up -d
WARN[0000] /Users/masa/Sources/udemy/line-bot-sample/docker-compose.yml: `version` is obsolete
WARN[0000] /Users/masa/Sources/udemy/line-bot-sample/docker-compose.yml: `version` is obsolete
[+] Running 2/0
 ✔ Container line-bot-sample-mysql-1         Running                                                                                                                                                                      0.0s
 ✔ Container line-bot-sample-laravel.test-1  Running                                                                                                                                                                      0.0s

```

### 変更後
```
❯ sail up -d
[+] Running 2/0
 ✔ Container line-bot-sample-mysql-1         Running                                                                                                                                                                      0.0s
 ✔ Container line-bot-sample-laravel.test-1  Running                                                                                                                                                                      0.0s
```